### PR TITLE
#30 - Feat 약속시간 탐색 예외 처리

### DIFF
--- a/promise/views/CreatePromiseOptionsView.py
+++ b/promise/views/CreatePromiseOptionsView.py
@@ -10,7 +10,7 @@ from promise.models import PromiseOption, Promise
 from plan.models import Plan
 from users.models import Profile
 
-from promise.serializers import CreatePromiseOptionsSerializer, PromiseOptionSerializer, PromiseSerializer
+from promise.serializers import CreatePromiseOptionsSerializer, PromiseSerializer
 
 
 # 가능한 약속시간 탐색
@@ -27,6 +27,13 @@ class CreatePromiseOptionsView(APIView):
         start_date = validated_data['start']
         end_date = validated_data['end']
         length = validated_data['length']
+
+        if (start_date == end_date):
+            return Response({"message": "시작 시간과 끝나는 시간이 같습니다."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        if (end_date - start_date < timedelta(hours=length)):
+            return Response({"message": "시작 시간과 끝나는 시간의 기간이 약속 길이보다 짧습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
 
         promise_options_except_only_me = []
 

--- a/promise/views/CreatePromiseOptionsView.py
+++ b/promise/views/CreatePromiseOptionsView.py
@@ -121,7 +121,7 @@ def isAvailable(user_profile, start, end):
     # 사용자 일정 조회
     plans = Plan.objects.filter(
         Q(author=user_profile),
-        Q(end__gte=start) & Q(start__lte=end)
+        Q(end__gt=start) & Q(start__lt=end)
     )
 
     # 만약 계획이 없다면 True 반환 (비어있음)


### PR DESCRIPTION
## Close Issue
closed #30 

## 작업 내용
- start = end 인 경우 400
- end - start < length인 경우 400
- isAvailable에 equal 조건 제거 => 9:00-10:00 일정이 있어도 8:00-9:00 약속을 허용 못하는 문제가 있어, equal 조건은 저게 했습니다. 

## 스크린샷
<img width="597" alt="image" src="https://github.com/user-attachments/assets/f0b3a401-a695-421c-b34d-2e2e1b86f255">
<img width="597" alt="image" src="https://github.com/user-attachments/assets/743f0e38-9cd6-4811-a11b-a82ec782b330">
